### PR TITLE
Eucalyptus 4.4.5 release announcement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,8 @@ languageCode = "en-us"
 title = "Eucalyptus Cloud : Blog"
 theme = "type"
 
+buildExpired = true
+buildFuture = true
 disqusShortname = ""
 googleAnalytics = ""
 paginate = 10

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,9 @@ paginate = 10
 themesDir = "themes"
 pygmentsUseClasses=true
 
+[taxonomies]
+	tag = "tags"
+
 [params]
 	author = ""
 	description = "Eucalyptus Cloud Blog"

--- a/content/post/eucalyptus-445-release.md
+++ b/content/post/eucalyptus-445-release.md
@@ -1,0 +1,32 @@
+---
+title: "Eucalyptus 4.4.5 Released"
+date: 2018-12-31T12:00:00-07:00
+tags:
+- announcement
+- release
+---
+
+Eucalyptus Cloud 4.4.5 has been released, updating our OS support to allow use of CentOS and RHEL 7.6 in addition to
+the existing support for 7.3, 7.4, and 7.5.
+
+This release has some important compatibility and functionality fixes and is recommended for all 4.4.x deployments.
+
+<!--more-->
+
+As with version 4.4.4, this release was tested using 2.9.0 qemu packages which should be installed when upgrading from
+earlier versions.
+
+Some fixes of note in this release are:
+
+* The object storage gateway now supports version two object listing
+* EC2 instances for some images could hang when starting
+
+You can find the full list of
+[resolved issues](https://docs.eucalyptus.cloud/eucalyptus/4.4.5/index.html#release-notes/4.4.5/4.4.5_rn_resolved.html)
+in the release notes.
+
+If upgrading from 4.4.2 or earlier, note that the RPM repository location has changed, updated Eucalyptus and Euca2ools
+release RPMs should be installed as detailed in the
+[install guide](https://docs.eucalyptus.cloud/eucalyptus/4.4.5/install-guide/installing_euca_release.html)
+so that the new downloads.eucalyptus.cloud location is used.
+

--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -1,0 +1,27 @@
+<div class="posts">
+	{{ range .Pages -}}
+	<div class="post-teaser">
+		<header>
+			<h1>
+			<a class="post-link" href="{{ .Permalink }}">
+				{{ .Title }}
+			</a>
+			</h1>
+			{{ partial "post-meta" . }}
+		</header>
+
+		<div class="excerpt">
+			{{ if isset .Params "description" | and (ne .Params.description "") -}}
+				{{ .Description | markdownify }}
+			{{- else -}}
+				{{ .Summary }}
+			{{- end }}
+
+			<br>
+			<a class="button" href="{{ .Permalink }}">
+				{{ .Site.Data.l10n.continueReading }}
+			</a>
+		</div>
+	</div>
+	{{- end }}
+</div>


### PR DESCRIPTION
Post for eucalyptus 4.4.5 release. 

Fix for tag pages, we were showing all pages for every tag. The `post-list.html` template is a copy of the [default for the theme](https://github.com/digitalcraftsman/hugo-type-theme/blob/master/layouts/partials/post-list.html), the only change is to use `{{ range .Pages -}}` (and this range is the same one used to [generate the rss](https://gohugo.io/templates/rss/#the-embedded-rss-xml) pages)